### PR TITLE
refactor(bgclicker/formabout.designer.cs): update about to 2021

### DIFF
--- a/bgclicker/formAbout.Designer.cs
+++ b/bgclicker/formAbout.Designer.cs
@@ -48,7 +48,7 @@
             this.label1.Size = new System.Drawing.Size(288, 85);
             this.label1.TabIndex = 2;
             this.label1.Text = "FLY BGClicker\r\nVer 1.1.5.20082201\r\nProgrammed by Edward Wang\r\nLicensed under GNU " +
-    "General Public License v3.0\r\nFLY Studio ©2011-2020 All Rights Reserved.";
+    "General Public License v3.0\r\nFLY Studio ©2011-2021 All Rights Reserved.";
             // 
             // btnClose
             // 


### PR DESCRIPTION
将 "FLY Studio ©2011-2020 All Rights Reserved." 改为 "FLY Studio ©2011-2021 All Rights Reserved."